### PR TITLE
Add Fetcher 429-response retry and more filtering features

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "mem": "^9.0.2",
     "nanostores": "^0.11.2",
     "next": "14.2.5",
-    "pixiv.ts": "0.6.3",
+    "pixiv.ts": "0.6.9",
     "postcss": "^8.4.41",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 14.2.5
         version: 14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       pixiv.ts:
-        specifier: 0.6.3
-        version: 0.6.3
+        specifier: 0.6.9
+        version: 0.6.9
       postcss:
         specifier: ^8.4.41
         version: 8.4.41
@@ -699,25 +699,15 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
-  big-integer@1.6.52:
-    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
-    engines: {node: '>=0.6'}
-
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  binary@0.3.0:
-    resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
-
   bing-translate-api@2.10.0:
     resolution: {integrity: sha512-jAxLMMftjB9KizG/IqUz+pyfB6n4Q8zu7LVgbAULeHbBvOy+Enwxm+f2uNrKTeiO4tKhNqi13Kjk29DOc+q/zw==}
 
-  bluebird@3.4.7:
-    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
-
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+  bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -728,14 +718,6 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  buffer-indexof-polyfill@1.0.2:
-    resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
-    engines: {node: '>=0.10'}
-
-  buffers@0.1.1:
-    resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
-    engines: {node: '>=0.2.0'}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -757,14 +739,11 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001651:
-    resolution: {integrity: sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==}
+  caniuse-lite@1.0.30001700:
+    resolution: {integrity: sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==}
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
-
-  chainsaw@0.1.0:
-    resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -814,9 +793,6 @@ packages:
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
@@ -982,18 +958,14 @@ packages:
     resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
     engines: {node: '>= 0.12'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+  fs-extra@11.3.0:
+    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
+    engines: {node: '>=14.14'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  fstream@1.0.12:
-    resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
-    engines: {node: '>=0.6'}
-    deprecated: This package is no longer supported.
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1023,10 +995,6 @@ packages:
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   got@11.8.6:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
@@ -1081,10 +1049,6 @@ packages:
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1174,6 +1138,9 @@ packages:
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
+  jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+
   jsprim@1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
     engines: {node: '>=0.6.0'}
@@ -1191,9 +1158,6 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-
-  listenercount@1.0.1:
-    resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -1255,23 +1219,13 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
 
   mrmime@2.0.0:
     resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
@@ -1319,6 +1273,9 @@ packages:
   node-bitmap@0.0.1:
     resolution: {integrity: sha512-Jx5lPaaLdIaOsj2mVLWMWulXF6GQVdyLvNSxmiYCvZ8Ma2hfKX0POoR2kgKOqz+oFsRreq0yYZjQ2wjE9VNzCA==}
     engines: {node: '>=v0.6.5'}
+
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -1386,10 +1343,6 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1423,8 +1376,8 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
-  pixiv.ts@0.6.3:
-    resolution: {integrity: sha512-DTWS7mChP2H8ZKz55Yj2aqzUQw1VHNmAgpT7ZkltDoS8+U3sNxCXiLgjX06IkBDskWPYSdn10WDXpKZoseD37w==}
+  pixiv.ts@0.6.9:
+    resolution: {integrity: sha512-T1ISC6jUGSDCTjS8hzAafKibnmcRMa6U+Y4vjL59BJOBWPO48tVZQ4DshcIimutldHYCoaWPapCmE9QYL10fSQ==}
 
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
@@ -1589,11 +1542,6 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1613,9 +1561,6 @@ packages:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
     engines: {node: '>=10'}
     hasBin: true
-
-  setimmediate@1.0.5:
-    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sharp@0.33.4:
     resolution: {integrity: sha512-7i/dt5kGl7qR4gwPRD2biwD2/SvBn3O04J77XKFgL2OnZtQw+AG9wnuS/csmu80nPRHLYE9E41fyEiG8nhH6/Q==}
@@ -1751,14 +1696,14 @@ packages:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
     engines: {node: '>=0.8'}
 
-  traverse@0.3.9:
-    resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
-
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -1777,8 +1722,12 @@ packages:
   uniq@1.0.1:
     resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
 
-  unzipper@0.10.14:
-    resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  unzipper@0.12.3:
+    resolution: {integrity: sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -2265,7 +2214,7 @@ snapshots:
 
   '@swc/helpers@0.5.12':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     optional: true
 
   '@swc/helpers@0.5.5':
@@ -2399,25 +2348,13 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  big-integer@1.6.52: {}
-
   binary-extensions@2.3.0: {}
-
-  binary@0.3.0:
-    dependencies:
-      buffers: 0.1.1
-      chainsaw: 0.1.0
 
   bing-translate-api@2.10.0:
     dependencies:
       got: 11.8.6
 
-  bluebird@3.4.7: {}
-
-  brace-expansion@1.1.11:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
+  bluebird@3.7.2: {}
 
   brace-expansion@2.0.1:
     dependencies:
@@ -2428,10 +2365,6 @@ snapshots:
       fill-range: 7.1.1
 
   buffer-from@1.1.2: {}
-
-  buffer-indexof-polyfill@1.0.2: {}
-
-  buffers@0.1.1: {}
 
   busboy@1.6.0:
     dependencies:
@@ -2453,13 +2386,9 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
-  caniuse-lite@1.0.30001651: {}
+  caniuse-lite@1.0.30001700: {}
 
   caseless@0.12.0: {}
-
-  chainsaw@0.1.0:
-    dependencies:
-      traverse: 0.3.9
 
   chalk@2.4.2:
     dependencies:
@@ -2516,8 +2445,6 @@ snapshots:
   commander@4.1.1: {}
 
   commander@7.2.0: {}
-
-  concat-map@0.0.1: {}
 
   convert-source-map@1.9.0: {}
 
@@ -2656,17 +2583,14 @@ snapshots:
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
-  fs.realpath@1.0.0: {}
+  fs-extra@11.3.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
 
   fsevents@2.3.3:
     optional: true
-
-  fstream@1.0.12:
-    dependencies:
-      graceful-fs: 4.2.11
-      inherits: 2.0.4
-      mkdirp: 0.5.6
-      rimraf: 2.7.1
 
   function-bind@1.1.2: {}
 
@@ -2712,15 +2636,6 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.0
       path-scurry: 1.11.1
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   got@11.8.6:
     dependencies:
@@ -2782,11 +2697,6 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -2852,6 +2762,12 @@ snapshots:
 
   json-stringify-safe@5.0.1: {}
 
+  jsonfile@6.1.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsprim@1.4.2:
     dependencies:
       assert-plus: 1.0.0
@@ -2868,8 +2784,6 @@ snapshots:
   lilconfig@3.1.2: {}
 
   lines-and-columns@1.2.4: {}
-
-  listenercount@1.0.1: {}
 
   lodash@4.17.21: {}
 
@@ -2915,21 +2829,11 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.11
-
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
 
-  minimist@1.2.8: {}
-
   minipass@7.1.2: {}
-
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
 
   mrmime@2.0.0: {}
 
@@ -2960,7 +2864,7 @@ snapshots:
       '@next/env': 14.2.5
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001651
+      caniuse-lite: 1.0.30001700
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 18.3.1
@@ -2981,6 +2885,8 @@ snapshots:
       - babel-plugin-macros
 
   node-bitmap@0.0.1: {}
+
+  node-int64@0.4.0: {}
 
   normalize-path@3.0.0: {}
 
@@ -3046,8 +2952,6 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
-  path-is-absolute@1.0.1: {}
-
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
@@ -3069,14 +2973,14 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  pixiv.ts@0.6.3:
+  pixiv.ts@0.6.9:
     dependencies:
       axios: 0.21.4
       bing-translate-api: 2.10.0
       get-pixels: 3.3.3
       gif-encoder: 0.7.2
       image-size: 0.8.3
-      unzipper: 0.10.14
+      unzipper: 0.12.3
     transitivePeerDependencies:
       - debug
 
@@ -3275,10 +3179,6 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -3294,8 +3194,6 @@ snapshots:
       loose-envify: 1.4.0
 
   semver@7.6.2: {}
-
-  setimmediate@1.0.5: {}
 
   sharp@0.33.4:
     dependencies:
@@ -3471,11 +3369,12 @@ snapshots:
       psl: 1.9.0
       punycode: 2.3.1
 
-  traverse@0.3.9: {}
-
   ts-interface-checker@0.1.13: {}
 
   tslib@2.6.3: {}
+
+  tslib@2.8.1:
+    optional: true
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -3489,18 +3388,15 @@ snapshots:
 
   uniq@1.0.1: {}
 
-  unzipper@0.10.14:
+  universalify@2.0.1: {}
+
+  unzipper@0.12.3:
     dependencies:
-      big-integer: 1.6.52
-      binary: 0.3.0
-      bluebird: 3.4.7
-      buffer-indexof-polyfill: 1.0.2
+      bluebird: 3.7.2
       duplexer2: 0.1.4
-      fstream: 1.0.12
+      fs-extra: 11.3.0
       graceful-fs: 4.2.11
-      listenercount: 1.0.1
-      readable-stream: 2.3.8
-      setimmediate: 1.0.5
+      node-int64: 0.4.0
 
   uri-js@4.4.1:
     dependencies:

--- a/src/context/SearchBarContext.ts
+++ b/src/context/SearchBarContext.ts
@@ -7,17 +7,25 @@ import { MinimumSizer } from '../core/@types/MinimumSizer'
 type ReactState<S = any> = [S, Dispatch<SetStateAction<S>>]
 
 interface Context {
-  tags: ReactState<string[]>
+  includeTags: ReactState<string[]>
+  excludeTags: ReactState<string[]>
   restriction: ReactState<'all' | 'public' | 'private'>
   aspect: ReactState<'all' | 'horizontal' | 'vertical'>
   minimumSizer: ReactState<MinimumSizer>
   blur: ReactState<boolean>
+  aiMode: ReactState<'all' | 'non-ai-only' | 'ai-only'>
+  minimumPageCount: ReactState<string>
+  maximumPageCount: ReactState<string>
 }
 
 export const SearchBarContext = createContext<Context>({
-  tags: [[], () => {}],
-  restriction: ['public', () => {}],
-  aspect: ['all', () => {}],
-  minimumSizer: [minimumSizer, () => {}],
-  blur: [true, () => {}],
+  includeTags: [[], () => { }],
+  excludeTags: [[], () => { }],
+  restriction: ['public', () => { }],
+  aspect: ['all', () => { }],
+  minimumSizer: [minimumSizer, () => { }],
+  blur: [true, () => { }],
+  aiMode: ['all', () => { }],
+  minimumPageCount: ['0', () => { }],
+  maximumPageCount: ['0', () => { }],
 })

--- a/src/core/@types/api/SearchRequest.ts
+++ b/src/core/@types/api/SearchRequest.ts
@@ -1,10 +1,14 @@
 import { MinimumSizer } from '../MinimumSizer'
 
 export interface SearchRequest {
-  page: string
-  tags: string[]
-  restrict: 'all' | 'public' | 'private'
-  aspect: 'all' | 'horizontal' | 'vertical'
-  sizerMode: MinimumSizer['mode']
-  sizerSize: string
+  page: string,
+  includeTags: string[],
+  excludeTags: string[],
+  restrict: 'all' | 'public' | 'private',
+  aspect: 'all' | 'horizontal' | 'vertical',
+  sizerMode: MinimumSizer['mode'],
+  sizerSize: string,
+  aiMode: 'all' | 'non-ai-only' | 'ai-only'
+  minimumPageCount: string,
+  maximumPageCount: string,
 }

--- a/src/core/@types/api/TagSearchResponse.ts
+++ b/src/core/@types/api/TagSearchResponse.ts
@@ -1,9 +1,13 @@
+
+export interface Tag {
+  name: {
+    original: string
+    translated: string | null
+  }
+  count: number
+}
+
+
 export interface TagSearchResponse {
-  tags: {
-    name: {
-      original: string
-      translated: string | null
-    }
-    count: number
-  }[]
+  tags: Tag[]
 }

--- a/src/modules/search/services/aiFilter.ts
+++ b/src/modules/search/services/aiFilter.ts
@@ -1,0 +1,17 @@
+import { ExtendedPixivIllust } from '../../../core/@types/ExtendedPixivIllust'
+import { SearchRequest } from '../../../core/@types/api/SearchRequest'
+/* 
+search ai contents
+note that illust_ai_type goes is one in {0,1,2}, with 2 meaning full AI and 0 meaning non-ai
+1 is thus nonconclusive and is reported as non-ai
+*/
+export const aiFilter =
+  (searchRequest: SearchRequest) =>
+    (illust: ExtendedPixivIllust): boolean => {
+      if (searchRequest.aiMode === 'all') return true
+      else if (searchRequest.aiMode === 'non-ai-only')
+        return illust.illust_ai_type !== 2
+      else if (searchRequest.aiMode === 'ai-only')
+        return illust.illust_ai_type === 2
+      return false
+    }

--- a/src/modules/search/services/pageCountFilter.ts
+++ b/src/modules/search/services/pageCountFilter.ts
@@ -1,0 +1,11 @@
+import { ExtendedPixivIllust } from '../../../core/@types/ExtendedPixivIllust'
+import { SearchRequest } from '../../../core/@types/api/SearchRequest'
+
+// search image count for work
+export const pageCountFilter =
+  (searchRequest: SearchRequest) =>
+    (illust: ExtendedPixivIllust): boolean => {
+      const maximumPageCount = Number(searchRequest.maximumPageCount);
+      return illust.page_count >= Number(searchRequest.minimumPageCount) && (maximumPageCount <= 0 || illust.page_count <= maximumPageCount)
+    }
+

--- a/src/modules/search/services/tagFilter.ts
+++ b/src/modules/search/services/tagFilter.ts
@@ -2,9 +2,10 @@ import { ExtendedPixivIllust } from '../../../core/@types/ExtendedPixivIllust'
 
 // search image tag
 export const tagFilter =
-  (searchTags: string[]) =>
-  (illust: ExtendedPixivIllust): boolean => {
-    return searchTags.length === 0
-      ? true
-      : searchTags.every(tag => illust.tags.map(o => o.name).includes(tag))
-  }
+  (includedTags: string[], excludedTags: string[]) =>
+    (illust: ExtendedPixivIllust): boolean => {
+      if (includedTags.length === 0 && excludedTags.length === 0) return true
+      const illustTagNames = illust.tags.map(o => o.name)
+      return includedTags.every(tag => illustTagNames.includes(tag)) &&
+        excludedTags.every(tag => !illustTagNames.includes(tag))
+    }

--- a/src/modules/searchBar/components/ai.tsx
+++ b/src/modules/searchBar/components/ai.tsx
@@ -1,0 +1,51 @@
+import { memo, useContext, useEffect, useState } from 'react'
+import { SearchBarContext } from '../../../context/SearchBarContext'
+
+import { classNames } from '../../../core/components/classNames'
+
+export const AiMode = memo(() => {
+  const [toggleAiOnly, setToggleAiOnly] = useState(true)
+  const [toggleNonAiOnly, setToggleNonAiOnly] = useState(true)
+
+  const searchBarContext = useContext(SearchBarContext)
+  const [_, setAiMode] = searchBarContext.aiMode
+
+  useEffect(() => {
+    const selectedMode =
+      toggleAiOnly === toggleNonAiOnly
+        ? 'all'
+        : toggleAiOnly
+        ? 'non-ai-only'
+        : 'ai-only'
+    setAiMode(selectedMode)
+  }, [toggleAiOnly, toggleNonAiOnly])
+
+  return (
+    <span className="isolate inline-flex rounded-md shadow-sm m-1">
+      <button
+        type="button"
+        onClick={() => setToggleAiOnly(o => !o)}
+        className={classNames(
+          toggleAiOnly
+            ? 'text-white bg-indigo-600 hover:bg-indigo-500'
+            : 'text-gray-700 bg-white hover:bg-gray-50',
+          'relative inline-flex items-center rounded-l-md border border-gray-300 px-4 py-2 text-sm font-medium focus:z-10 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500'
+        )}
+      >
+        Non-Ai
+      </button>
+      <button
+        type="button"
+        onClick={() => setToggleNonAiOnly(o => !o)}
+        className={classNames(
+          toggleNonAiOnly
+            ? 'text-white bg-indigo-600 hover:bg-indigo-500'
+            : 'text-gray-700 bg-white hover:bg-gray-50',
+          'relative -ml-px inline-flex items-center rounded-r-md border border-gray-300 px-4 py-2 text-sm font-medium focus:z-10 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500'
+        )}
+      >
+        Ai
+      </button>
+    </span>
+  )
+})

--- a/src/modules/searchBar/components/index.tsx
+++ b/src/modules/searchBar/components/index.tsx
@@ -6,6 +6,8 @@ import { Restriction } from './restriction'
 import { Aspect } from './aspect'
 import { Sizer } from './sizer'
 import { Checks } from './checks'
+import { PageCount } from './pageCount'
+import { AiMode } from './ai'
 
 const TagSeachBar = dynamic(() => import('./tag').then(o => o.TagSeachBar))
 
@@ -16,7 +18,9 @@ export const SearchBar: FunctionComponent = () => {
         <Restriction />
         <Aspect />
         <Sizer />
+        <AiMode />
         <Checks />
+        <PageCount />
       </div>
       <TagSeachBar />
     </div>

--- a/src/modules/searchBar/components/index.tsx
+++ b/src/modules/searchBar/components/index.tsx
@@ -8,6 +8,7 @@ import { Sizer } from './sizer'
 import { Checks } from './checks'
 import { PageCount } from './pageCount'
 import { AiMode } from './ai'
+import TagCount from './tagCounts'
 
 const TagSeachBar = dynamic(() => import('./tag').then(o => o.TagSeachBar))
 
@@ -23,6 +24,7 @@ export const SearchBar: FunctionComponent = () => {
         <PageCount />
       </div>
       <TagSeachBar />
+      <TagCount />
     </div>
   )
 }

--- a/src/modules/searchBar/components/pageCount.tsx
+++ b/src/modules/searchBar/components/pageCount.tsx
@@ -1,0 +1,55 @@
+import { ChangeEventHandler, memo, useCallback, useContext } from 'react'
+import { SearchBarContext } from '../../../context/SearchBarContext'
+
+export const PageCount = memo(() => {
+  const searchBarContext = useContext(SearchBarContext)
+  const [minimumPageCount, setMinimumPageCount] = searchBarContext.minimumPageCount
+  const [maximumPageCount, setMaximumPageCount] = searchBarContext.maximumPageCount
+
+  const onMinimumValueChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
+    ({ target: { value } }) => {
+      setMinimumPageCount(value)
+    },
+    []
+  )
+
+  const onMaximumValueChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
+    ({ target: { value } }) => {
+      setMaximumPageCount(value)
+    },
+    []
+  )
+
+  return (
+    <span className="isolate inline-flex rounded-md shadow-sm m-1">
+      <div className="relative inline-flex items-center rounded-l-md rounded-r-md border border-gray-300 px-4 py-2 text-sm font-medium focus:z-10 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500">
+        <div>
+          <label htmlFor="minimumPageCount" className="font-medium text-gray-900">
+            Minimum page count:
+          </label>
+          <input
+            id="minimumPageCount"
+            name="minimumPageCount"
+            value={minimumPageCount}
+            onChange={onMinimumValueChange}
+            type="number"
+            className="max-width:10px rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+          />
+        </div>
+        <div>
+          <label htmlFor="maximumPageCount" className="font-medium text-gray-900">
+            Maximum page count:
+          </label>
+          <input
+            id="maximumPageCount"
+            name="maximumPageCount"
+            value={maximumPageCount}
+            onChange={onMaximumValueChange}
+            type="number"
+            className="max-width:10px rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+          />
+        </div>
+      </div>
+    </span>
+  )
+})

--- a/src/modules/searchBar/components/pageCount.tsx
+++ b/src/modules/searchBar/components/pageCount.tsx
@@ -33,7 +33,7 @@ export const PageCount = memo(() => {
             value={minimumPageCount}
             onChange={onMinimumValueChange}
             type="number"
-            className="max-width:10px rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+            className="max-width-[30px] rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
           />
         </div>
         <div>
@@ -46,7 +46,7 @@ export const PageCount = memo(() => {
             value={maximumPageCount}
             onChange={onMaximumValueChange}
             type="number"
-            className="max-width:10px rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+            className="max-width-[30px] rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
           />
         </div>
       </div>

--- a/src/modules/searchBar/components/tag.tsx
+++ b/src/modules/searchBar/components/tag.tsx
@@ -11,16 +11,20 @@ import { SearchBarContext } from '../../../context/SearchBarContext'
 
 export const TagSeachBar = memo(() => {
   const searchBarContext = useContext(SearchBarContext)
-  const [tags, setTags] = searchBarContext.tags
+  const [includeTags, setIncludeTags] = searchBarContext.includeTags
+  const [excludeTags, setExcludeTags] = searchBarContext.excludeTags
 
-  const [loading, setLoading] = useState(false)
-  const tagLoadOptions = async (inputValue: string) => {
+  const [loadingIncludedTags, setLoadingIncludedTags] = useState(false)
+  const [loadingExcludedTags, setLoadingExcludedTags] = useState(false)
+
+  // This code must be duplicated due to the separation of results
+  const includedTagLoadOptions = async (inputValue: string) => {
     try {
-      setLoading(true)
+      setLoadingIncludedTags(true)
 
       const tagSearchPayload: TagSearchRequest = {
         query: inputValue,
-        selectedTags: tags,
+        selectedTags: includeTags,
       }
 
       const expectedResults: TagSearchResponse = await fetch(
@@ -45,25 +49,80 @@ export const TagSeachBar = memo(() => {
       console.error(e)
       return []
     } finally {
-      setLoading(false)
+      setLoadingIncludedTags(false)
+    }
+  }
+
+  const excludedTagLoadOptions = async (inputValue: string) => {
+    try {
+      setLoadingExcludedTags(true)
+
+      const tagSearchPayload: TagSearchRequest = {
+        query: inputValue,
+        selectedTags: excludeTags,
+      }
+
+      const expectedResults: TagSearchResponse = await fetch(
+        `/api/tagSearch?${buildURLParams(tagSearchPayload)}`
+      ).then(o => o.json())
+
+      return expectedResults.tags.map(tag => ({
+        value: tag.name.original,
+        label: (
+          <p className="flex items-center">
+            <span className="font-medium">{tag.name.original}</span>
+            <span className="ml-2 text-gray-500 text-sm">
+              {tag.name.translated}
+            </span>
+            <span className="text-xs text-white bg-gray-900 py-0.5 px-2 rounded-md ml-2">
+              {tag.count}
+            </span>
+          </p>
+        ),
+      }))
+    } catch (e) {
+      console.error(e)
+      return []
+    } finally {
+      setLoadingIncludedTags(false)
     }
   }
 
   return (
-    <Async
-      isMulti
-      loadOptions={tagLoadOptions}
-      isLoading={loading}
-      onChange={val => setTags(val.map(o => o.value))}
-      components={{
-        MenuList: WindowedMenuList,
-      }}
-      styles={{
-        menu: provided => ({
-          ...provided,
-          zIndex: 10,
-        }),
-      }}
-    />
+    <div>
+      <label htmlFor="tagsLabel" className="font-medium text-gray-900">
+        Tag filtering
+      </label>
+      <Async
+        isMulti
+        loadOptions={includedTagLoadOptions}
+        isLoading={loadingIncludedTags}
+        onChange={val => setIncludeTags(val.map(o => o.value))}
+        components={{
+          MenuList: WindowedMenuList,
+        }}
+        styles={{
+          menu: provided => ({
+            ...provided,
+            zIndex: 10,
+          }),
+        }}
+      />
+      <Async
+        isMulti
+        loadOptions={excludedTagLoadOptions}
+        isLoading={loadingExcludedTags}
+        onChange={val => setExcludeTags(val.map(o => o.value))}
+        components={{
+          MenuList: WindowedMenuList,
+        }}
+        styles={{
+          menu: provided => ({
+            ...provided,
+            zIndex: 10,
+          }),
+        }}
+      />
+    </div>
   )
 })

--- a/src/modules/searchBar/components/tagCounts.tsx
+++ b/src/modules/searchBar/components/tagCounts.tsx
@@ -1,0 +1,84 @@
+import React, { memo, useEffect, useState } from 'react';
+import { TagSearchResponse, Tag } from '../../../core/@types/api/TagSearchResponse';
+
+export const TagCount = memo(() => {
+    const [isCollapsed, setIsCollapsed] = useState<boolean>(true);
+    const [tags, setTags] = useState<Tag[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const toggleCollapse = () => {
+        setIsCollapsed(!isCollapsed);
+    };
+
+    useEffect(() => {
+        const fetchTags = async () => {
+            try {
+                setLoading(true)
+
+                const expectedResults: TagSearchResponse = await fetch(
+                    `/api/tagSearch?`
+                ).then(o => o.json())
+
+                let sortedTags = expectedResults.tags.sort((a, b) => b.count - a.count)
+                setTags(
+                    sortedTags.length <= 15 ? sortedTags : sortedTags.slice(0, 15)
+                )
+            } catch (e) {
+                console.error(e)
+                setTags([])
+                setError(e.message)
+            } finally {
+                setLoading(false)
+            }
+        };
+
+        fetchTags();
+    }, []);
+
+    if (loading) {
+        return <div>Loading...</div>;
+    }
+
+    if (error) {
+        return <div>Error: {error}</div>;
+    }
+
+
+    return (
+        <span className="isolate inline-flex rounded-md shadow-sm">
+            <div style={{ border: '1px solid #ccc', padding: '10px', borderRadius: '5px', maxWidth: '500px', margin: '0 auto' }}>
+                <label htmlFor="tagsLabel" className="font-medium text-gray-900">
+                    Top 10 tags:
+                </label>
+                <button onClick={toggleCollapse} style={{ marginBottom: '10px', padding: '5px 10px', cursor: 'pointer' }}>
+                    {isCollapsed ? 'Expand' : 'Collapse'}
+                </button>
+                <div
+                    style={{
+                        maxHeight: isCollapsed ? '0' : '500px', // Adjust max height for smooth transition
+                        overflow: 'hidden',
+                        transition: 'max-height 0.3s ease-in-out', // Smooth transition
+                    }}
+                >
+                    {tags.map((tag, index) => (
+                        <span className="rounded-l-md rounded-r-md border border-gray-300"
+                            key={index}
+                            style={{
+                                fontSize: `14px`, // Set font size based on word count
+                                margin: '5px',
+                                display: 'inline-block',
+                                transition: 'font-size 0.2s ease-in-out', // Smooth font size transition
+                                padding: '5px',
+                            }}
+                        >
+                            {tag.name.translated ?? tag.name.original}
+                        </span>
+                    ))}
+                </div>
+            </div>
+        </span>
+    );
+});
+
+export default TagCount;

--- a/src/pages/[page].tsx
+++ b/src/pages/[page].tsx
@@ -17,10 +17,14 @@ const Page: NextPage = props => {
 
   // Context
   const searchBarContext = useContext(SearchBarContext)
-  const [tags] = searchBarContext.tags
+  const [includeTags] = searchBarContext.includeTags
+  const [excludeTags] = searchBarContext.excludeTags
   const [restrict] = searchBarContext.restriction
   const [aspect] = searchBarContext.aspect
   const [minimumSizer] = searchBarContext.minimumSizer
+  const [aiMode] = searchBarContext.aiMode
+  const [minimumPageCount] = searchBarContext.minimumPageCount
+  const [maximumPageCount] = searchBarContext.maximumPageCount
 
   const pageNumber = useMemo(
     () => (query.page === undefined ? 1 : Number(query.page as string)),
@@ -30,13 +34,17 @@ const Page: NextPage = props => {
   const searchPayload = useMemo<SearchRequest>(
     () => ({
       page: pageNumber.toString(),
-      tags,
+      includeTags: includeTags,
+      excludeTags: excludeTags,
       restrict,
       aspect,
       sizerMode: minimumSizer.mode,
       sizerSize: minimumSizer.size.toString(),
+      aiMode: aiMode,
+      minimumPageCount: minimumPageCount,
+      maximumPageCount: maximumPageCount,
     }),
-    [pageNumber, tags, restrict, aspect, minimumSizer.mode, minimumSizer.size]
+    [pageNumber, includeTags, excludeTags, restrict, aspect, minimumSizer.mode, minimumSizer.size, aiMode, minimumPageCount, maximumPageCount]
   )
 
   const { data, error } = useSWR<SearchResult, any, string>(

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -17,11 +17,15 @@ import '../styles/tailwind.css'
 const App: NextPage<AppProps> = props => {
   const { Component, pageProps } = props
 
-  const tagState = useState<string[]>([])
+  const includedTagsState = useState<string[]>([])
+  const excludedTagsState = useState<string[]>([])
   const restrictState = useState<'all' | 'public' | 'private'>('public')
   const aspectState = useState<'all' | 'horizontal' | 'vertical'>('all')
   const minimumSizerState = useState<MinimumSizer>(minimumSizer)
   const blurState = useState<boolean>(false)
+  const ai = useState<'all' | 'non-ai-only' | 'ai-only'>('all')
+  const minimumPageCount = useState<string>('0')
+  const maximumPageCount = useState<string>('0')
 
   return (
     <SWRConfig 
@@ -34,11 +38,15 @@ const App: NextPage<AppProps> = props => {
       </Head>
       <SearchBarContext.Provider
         value={{
-          tags: tagState,
+          includeTags: includedTagsState,
+          excludeTags: excludedTagsState,
           restriction: restrictState,
           aspect: aspectState,
           minimumSizer: minimumSizerState,
           blur: blurState,
+          aiMode: ai,
+          minimumPageCount: minimumPageCount,
+          maximumPageCount: maximumPageCount,
         }}
       >
         <main className="max-w-7xl mx-auto px-4 py-8">

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -7,9 +7,11 @@ import { restrictionFilter } from '../../modules/search/services/restrictionFilt
 import { sizeFilter } from '../../modules/search/services/sizeFilter'
 import { supporterFilter } from '../../modules/search/services/supporterFilter'
 import { tagFilter } from '../../modules/search/services/tagFilter'
+import { pageCountFilter } from '../../modules/search/services/pageCountFilter'
 
 import { SearchRequest } from '../../core/@types/api/SearchRequest'
 import { SearchResult } from '../../core/@types/api/SearchResult'
+import { aiFilter } from '../../modules/search/services/aiFilter'
 
 const api: NextApiHandler = async (req, res) => {
   const illusts = await getIllusts()
@@ -17,18 +19,28 @@ const api: NextApiHandler = async (req, res) => {
   const searchRequest = req.query as unknown as SearchRequest
   const targetPage = Number(searchRequest.page)
 
-  const searchTags =
-    searchRequest.tags === undefined
+  const includedTags =
+    searchRequest.includeTags === undefined
       ? []
-      : typeof searchRequest.tags === 'string'
-      ? [searchRequest.tags]
-      : searchRequest.tags
+      : typeof searchRequest.includeTags === 'string'
+        ? [searchRequest.includeTags]
+        : searchRequest.includeTags
+
+  const excludedTags =
+    searchRequest.excludeTags === undefined
+      ? []
+      : typeof searchRequest.excludeTags === 'string'
+        ? [searchRequest.excludeTags]
+        : searchRequest.excludeTags
 
   const filteredIllusts = illusts
     .filter(restrictionFilter(searchRequest))
     .filter(aspectFilter(searchRequest))
     .filter(sizeFilter(searchRequest))
-    .filter(tagFilter(searchTags))
+    .filter(tagFilter(includedTags, excludedTags))
+    .filter(pageCountFilter(searchRequest))
+    .filter(aiFilter(searchRequest))
+  //.filter(supporterFilter(searchRequest)) // Broken support
 
   const illustChunks = chunk(filteredIllusts, 30)
 

--- a/src/pages/api/tagSearch.ts
+++ b/src/pages/api/tagSearch.ts
@@ -23,8 +23,8 @@ const api: NextApiHandler = async (req, res) => {
     selectedTags === undefined
       ? []
       : typeof selectedTags === 'string'
-      ? [selectedTags]
-      : selectedTags
+        ? [selectedTags]
+        : selectedTags
 
   const searchedTags = illusts
     .map(o => o.tags)
@@ -32,8 +32,8 @@ const api: NextApiHandler = async (req, res) => {
       transformedSelectedTags.length === 0
         ? true
         : !transformedSelectedTags.some(selectedTag =>
-            illustTags.every(o => o.name !== selectedTag)
-          )
+          illustTags.every(o => o.name !== selectedTag)
+        )
     )
     .flat()
   const processedTags: NumberizedTag[] = reverse(
@@ -53,12 +53,12 @@ const api: NextApiHandler = async (req, res) => {
 
   const payload: TagSearchResponse = {
     tags: processedTags.filter(tag =>
-      query.length === 0
+      query === undefined || query.length === 0
         ? true
         : tag.name.original.toLowerCase().includes(query.toLowerCase()) ||
-          (tag.name.translated ?? '')
-            .toLowerCase()
-            .includes(query.toLowerCase())
+        (tag.name.translated ?? '')
+          .toLowerCase()
+          .includes(query.toLowerCase())
     ),
   }
 


### PR DESCRIPTION
Added some features I found useful as I used the app on a rather large collection of bookmarks.
- The fetcher will attempt to wait out 429 (too many requests) responses as opposed to completely halting.
- Ai filtering (ai-only/non-ai only/all).
- Page count filtering (minimum and maximum page count).
- Excluded tags (as opposed as only having included tags, you can also have both included and excluded tags).
- A summary showing the top 10 highest tags.
Below is an image of how the search bar looks:
![image](https://github.com/user-attachments/assets/af77c799-8b8a-4aad-9fcd-ec525da08feb)